### PR TITLE
Feat/utils - Criação dos utils para formatação de telefone e data

### DIFF
--- a/client/src/components/common/EmployeeTable/index.tsx
+++ b/client/src/components/common/EmployeeTable/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import ChevronDown from "../icons/ChevronDown";
 import ChevronUp from "../icons/ChevronUp";
+import { formatPhone } from "../../../utils/formatPhone";
 
 interface Employee {
   id: number;
@@ -93,7 +94,7 @@ const EmployeeTable: React.FC<{ filter: string }> = ({ filter }) => {
                     {new Date(employee.admission_date).toLocaleDateString()}
                   </td>
                   <td className="text-neutral-1 text-sm p-little-08 text-left pr-0">
-                    {employee.phone}
+                    {formatPhone(employee.phone)}
                   </td>
                 </tr>
               ))}
@@ -155,7 +156,7 @@ const EmployeeTable: React.FC<{ filter: string }> = ({ filter }) => {
                   {new Date(employee.admission_date).toLocaleDateString()}
                 </p>
                 <p>
-                  <strong>Telefone:</strong> {employee.phone}
+                  <strong>Telefone:</strong> {formatPhone(employee.phone)}
                 </p>
               </div>
             )}

--- a/client/src/components/common/EmployeeTable/index.tsx
+++ b/client/src/components/common/EmployeeTable/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import ChevronDown from "../icons/ChevronDown";
 import ChevronUp from "../icons/ChevronUp";
 import { formatPhone } from "../../../utils/formatPhone";
+import { formatDate } from "../../../utils/formatDate";
 
 interface Employee {
   id: number;
@@ -91,7 +92,7 @@ const EmployeeTable: React.FC<{ filter: string }> = ({ filter }) => {
                     {employee.job}
                   </td>
                   <td className="text-neutral-1 text-sm p-little-08 text-left">
-                    {new Date(employee.admission_date).toLocaleDateString()}
+                    {formatDate(employee.admission_date)}
                   </td>
                   <td className="text-neutral-1 text-sm p-little-08 text-left pr-0">
                     {formatPhone(employee.phone)}
@@ -153,7 +154,7 @@ const EmployeeTable: React.FC<{ filter: string }> = ({ filter }) => {
                 </p>
                 <p>
                   <strong>Data de Admissão:</strong>{" "}
-                  {new Date(employee.admission_date).toLocaleDateString()}
+                  {formatDate(employee.admission_date)}
                 </p>
                 <p>
                   <strong>Telefone:</strong> {formatPhone(employee.phone)}

--- a/client/src/utils/formatDate.ts
+++ b/client/src/utils/formatDate.ts
@@ -1,0 +1,9 @@
+export const formatDate = (date: string): string => {
+  const parsedDate = new Date(date);
+
+  if (isNaN(parsedDate.getTime())) {
+    return date;
+  }
+
+  return parsedDate.toLocaleDateString("pt-BR");
+};

--- a/client/src/utils/formatPhone.ts
+++ b/client/src/utils/formatPhone.ts
@@ -1,0 +1,10 @@
+export const formatPhone = (phone: string): string => {
+  const regex = /^(\d{2})(\d{2})(\d{5})(\d{4})$/;
+  const match = phone.match(regex);
+
+  if (match) {
+    return `+${match[1]} (${match[2]}) ${match[3]}-${match[4]}`;
+  }
+
+  return phone;
+};


### PR DESCRIPTION
## Descrição
Este pull request implementa a criação de dois novos **utils** para melhorar a formatação de dados exibidos na tabela de funcionários. Os utils são responsáveis por formatar o número de telefone e a data de admissão dos funcionários.

- **Utils `formatPhoneNumber`**: Formata números de telefone no formato `+XX (XX) XXXXX-XXXX`.
- **Utils `formatDate`**: Formata a data de admissão para o formato `dd/mm/yyyy`.

## Alterações realizadas

- **Utils `formatPhoneNumber`**:
  - Criado para formatar o número de telefone no formato `+XX (XX) XXXXX-XXXX`, utilizando uma expressão regular.
  - Caso o número não corresponda ao formato esperado, o número é retornado como está.
  - **Exemplo de uso**: `formatPhoneNumber('1234567890')` → `+12 (34) 56789-0123`

- **Utils `formatDate`**:
  - Criado para formatar datas no formato `dd/mm/yyyy`, utilizando o método `toLocaleDateString` da `Date`.
  - Caso a data seja inválida, a data original é retornada sem modificações.
  - **Exemplo de uso**: `formatDate('2025-03-20T00:00:00Z')` → `20/03/2025`

## Objetivo das alterações
- **Melhorar a modularização do código**: A lógica de formatação foi isolada em utils para reutilização em vários lugares do código.
- **Facilitar a manutenção**: Alterações nas lógicas de formatação de telefone e data agora podem ser feitas em um único local.
- **Aumentar a clareza do código**: A lógica de formatação foi movida para funções utilitárias, tornando o código mais limpo e organizado.